### PR TITLE
Use termopen() instead of term_start() when on Neovim

### DIFF
--- a/autoload/pio.vim
+++ b/autoload/pio.vim
@@ -287,7 +287,7 @@ function! pio#OpenTermOnce(command, buffername)
     execute 'bd! '.winbufnr(winnr)
     "execute winnr.'wincmd c'
   endif
-  call term_start(a:command,{'term_name':a:buffername})
+  call termopen(a:command,{'term_name':a:buffername})
   if a:command =~ '^platformio *lib *search.*$'
     setlocal filetype=piolibraries
     nnoremap <buffer> <CR> :call pio#PIOInstall(getline('.'))<CR>

--- a/autoload/pio.vim
+++ b/autoload/pio.vim
@@ -287,7 +287,11 @@ function! pio#OpenTermOnce(command, buffername)
     execute 'bd! '.winbufnr(winnr)
     "execute winnr.'wincmd c'
   endif
-  call termopen(a:command,{'term_name':a:buffername})
+  if has('nvim')
+    call termopen(a:command,{'term_name':a:buffername})
+  elseif has('vim')
+    call term_start(a:command,{'term_name':a:buffername})
+  endif
   if a:command =~ '^platformio *lib *search.*$'
     setlocal filetype=piolibraries
     nnoremap <buffer> <CR> :call pio#PIOInstall(getline('.'))<CR>


### PR DESCRIPTION
The `term_start()` function is called `termopen()` on Neovim, so this plugin doesn't work when using it on Neovim.
It appears (from what I used) that the only incompatible thing is this function, so this PR fixes this incompatibility by checking the running editor and executing the proper command.